### PR TITLE
Update ApiResponseFormatter due to yiisoft/data-response changes

### DIFF
--- a/src/Formatter/ApiResponseFormatter.php
+++ b/src/Formatter/ApiResponseFormatter.php
@@ -23,10 +23,10 @@ final class ApiResponseFormatter implements DataResponseFormatterInterface
         $this->jsonDataResponseFormatter = $jsonDataResponseFormatter;
     }
 
-    public function format(DataResponse $response): ResponseInterface
+    public function format(DataResponse $dataResponse): ResponseInterface
     {
-        $response = $response->withData(
-            $this->apiResponseDataFactory->createFromResponse($response)->toArray(),
+        $response = $dataResponse->withData(
+            $this->apiResponseDataFactory->createFromResponse($dataResponse)->toArray(),
         );
 
         return $this->jsonDataResponseFormatter->format($response);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Because of renaming the variable to `DataResponseFormatterInterface::format()`, static analysis tests fall.
