### PR TITLE
Increase `yiisoft/definitions` version to `^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "yiisoft/config": "^1.0",
         "yiisoft/data": "^3.0@dev",
         "yiisoft/data-response": "^1.0",
-        "yiisoft/definitions": "^1.0",
+        "yiisoft/definitions": "^2.0",
         "yiisoft/di": "^1.0",
         "yiisoft/error-handler": "^2.0",
         "yiisoft/factory": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Merge after released:

- Yii Definitions 2.0.0
- Yii DI 1.0.3
- Yii Factory 1.0.1
- Yii Widget 1.0.1
- Yii Runner 1.1.1
- Yii Runner Console 1.0.1
- Yii Runner HTTP 1.0.1