### PR TITLE
Upgrade php8.0 to 8.1 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
     php:
         container_name: yii-php
-        image: yiisoftware/yii-php:8.0-fpm
+        image: yiisoftware/yii-php:8.1-fpm
         working_dir: /app
         volumes:
             - ./:/app


### PR DESCRIPTION
fix Error: Your Composer dependencies require a PHP version ">= 8.1.0".

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
