### PR TITLE
The incompatible version of symfony/console has been fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
         "psr/log": "^3.0.2",
-        "symfony/console": "^7.4.4",
+        "symfony/console": "<=7.3",
         "yiisoft/aliases": "^3.1.1",
         "yiisoft/config": "^1.6.2",
         "yiisoft/data": "^1.0.1",


### PR DESCRIPTION
The symfony/console version 7.4 is incompatible because it requires symfony/string: ^7.2|^8.0. The 8.0 version requires PHP: >=8.4. However, the app template php: 8.2 - 8.5.
