### PR TITLE
Fix #276: Add `make open` and improve `make up` UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.1 under development
 
-- Enh: Add `make open` and improve `make up` UX (@samdark)
+- Enh #276: Add `make open` and improve `make up` UX (@samdark)
 
 ## 1.4.0 April 12, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.1 under development
 
-- no changes in this release.
+- Enh: Add `make open` and improve `make up` UX (@samdark)
 
 ## 1.4.0 April 12, 2026
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,48 @@ endif
 
 ifeq ($(PRIMARY_GOAL),up)
 up: ## Up the dev environment.
-	$(DOCKER_COMPOSE_DEV) up -d --remove-orphans
+	@set -eu; \
+	if $(DOCKER_COMPOSE_DEV) up -d --wait --wait-timeout 60 --remove-orphans; then \
+		port="$$( $(DOCKER_COMPOSE_DEV) port app 80 )"; \
+		host_port="$${port##*:}"; \
+		url="http://localhost$$( [ "$$host_port" = '80' ] || printf ':%s' "$$host_port" )"; \
+		printf 'Started server at %s\n' "$$url"; \
+	else \
+		echo 'Failed to start server.' >&2; \
+		container_id="$$( $(DOCKER_COMPOSE_DEV) ps -a -q app 2>/dev/null || true )"; \
+		if [ -n "$$container_id" ]; then \
+			state="$$(docker inspect -f '{{.State.Status}}' "$$container_id" 2>/dev/null || true)"; \
+			health="$$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$$container_id" 2>/dev/null || true)"; \
+			exit_code="$$(docker inspect -f '{{.State.ExitCode}}' "$$container_id" 2>/dev/null || true)"; \
+			error="$$(docker inspect -f '{{.State.Error}}' "$$container_id" 2>/dev/null || true)"; \
+			if [ -n "$$error" ]; then \
+				exit 1; \
+			fi; \
+			[ -n "$$health" ] && echo "Container health: $$health" >&2; \
+			[ -n "$$state" ] && echo "Container state: $$state" >&2; \
+			[ -n "$$exit_code" ] && echo "Container exit code: $$exit_code" >&2; \
+			echo 'Recent logs:' >&2; \
+			$(DOCKER_COMPOSE_DEV) logs --tail=50 app >&2 || true; \
+		fi; \
+		exit 1; \
+	fi
+endif
+
+ifeq ($(PRIMARY_GOAL),open)
+open: ## Open the running app in the default browser.
+	@set -eu; \
+	if ! port="$$( $(DOCKER_COMPOSE_DEV) port app 80 2>/dev/null )" || [ -z "$$port" ]; then \
+		echo 'Start server with `make up` first.' >&2; \
+		exit 0; \
+	fi; \
+	host_port="$${port##*:}"; \
+	url="http://localhost$$( [ "$$host_port" = '80' ] || printf ':%s' "$$host_port" )"; \
+	opener="$$(command -v xdg-open || command -v open || command -v wslview || true)"; \
+	if [ -z "$$opener" ]; then \
+		echo "Could not open $$url." >&2; \
+		exit 0; \
+	fi; \
+	"$$opener" "$$url" >/dev/null 2>&1 &
 endif
 
 ifeq ($(PRIMARY_GOAL),down)

--- a/README.md
+++ b/README.md
@@ -85,13 +85,19 @@ To run the app:
 make up
 ```
 
+To open the running app in your default browser:
+
+```shell
+make open
+```
+
 To stop the app:
 
 ```shell
 make down
 ```
 
-The application is available at `https://localhost`.
+The application is available at `http://localhost`.
 
 Other make commands are available in the `Makefile` and can be listed with:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

It adds `make open` that opens the app in the browser.

Also, it enhances the output of `make up`:

<img width="642" height="167" alt="image" src="https://github.com/user-attachments/assets/12c68022-3d21-4f8e-aa1f-a270b0199ab1" />

And in case of failure:

<img width="2294" height="306" alt="image" src="https://github.com/user-attachments/assets/d3a4ce95-c116-4218-961a-6b7e2b94d2c3" />
