### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
+      ignore:
+        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:
@@ -20,3 +22,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+      ignore:
+        - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 version: 2
 updates:
-    # Maintain dependencies for GitHub Actions.
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-      open-pull-requests-limit: 0
-
-    # Maintain dependencies for Composer
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      versioning-strategy: increase-if-necessary
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"\n    directory: "/"\n    schedule:\n      interval: "weekly"\n    cooldown:\n      default-days: 7\n    ignore:\n      - dependency-name: "yiisoft/*"\n    # Maintain dependencies for GitHub Actions.
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-      open-pull-requests-limit: 0
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"
 
-    # Maintain dependencies for Composer
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      versioning-strategy: increase-if-necessary
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+        interval: "daily"
+    versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
-      ignore:
-        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
+      ignore:
+        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-    # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"\n    directory: "/"\n    schedule:\n      interval: "weekly"\n    cooldown:\n      default-days: 7\n    ignore:\n      - dependency-name: "yiisoft/*"\n    # Maintain dependencies for GitHub Actions.
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
@@ -9,18 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
-      ignore:
-        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:
           interval: "daily"
       versioning-strategy: increase-if-necessary
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      ignore:
-        - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,19 @@
 version: 2
 updates:
+    # Maintain dependencies for GitHub Actions.
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
+      open-pull-requests-limit: 0
+
+    # Maintain dependencies for Composer
+    - package-ecosystem: "composer"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      versioning-strategy: increase-if-necessary
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     schedule:
         interval: "daily"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ on:
 
 name: build
 
+permissions:
+  contents: read
+
 jobs:
   codeception:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -45,10 +48,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: false
           extensions: fileinfo, intl
@@ -56,7 +61,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Run codeception build.
         run: vendor/bin/codecept build
@@ -72,7 +77,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: runtime/tests/_output/coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
 
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -48,12 +52,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: false
           extensions: fileinfo, intl
@@ -61,7 +65,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Run codeception build.
         run: vendor/bin/codecept build
@@ -77,7 +81,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: runtime/tests/_output/coverage.xml

--- a/.github/workflows/composer-dependency-analyzer.yml
+++ b/.github/workflows/composer-dependency-analyzer.yml
@@ -22,6 +22,10 @@ on:
 
 name: Composer dependency analyzer
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -43,19 +47,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Run composer dependency analyzer
         run: vendor/bin/composer-dependency-analyser --config=composer-dependency-analyser.php

--- a/.github/workflows/composer-dependency-analyzer.yml
+++ b/.github/workflows/composer-dependency-analyzer.yml
@@ -22,6 +22,9 @@ on:
 
 name: Composer dependency analyzer
 
+permissions:
+  contents: read
+
 jobs:
   analyzer:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -40,17 +43,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Run composer dependency analyzer
         run: vendor/bin/composer-dependency-analyser --config=composer-dependency-analyser.php

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,5 +1,8 @@
 name: Code Style
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths-ignore:
@@ -17,17 +20,19 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: 8.2
           tools: composer:v2
           coverage: none
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v4"
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
@@ -35,8 +40,13 @@ jobs:
       - name: Run Rector
         run: ./vendor/bin/rector --output-format=github
 
+      - name: Configure Git credentials
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
+
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         with:
           commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
           file_pattern: '*.php'

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,5 +1,9 @@
 name: Code Style
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -15,24 +19,25 @@ on:
 
 jobs:
   cs-fix:
+    name: PHP CS Fixer and Rector
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to push automated CS fixes to the pull request branch.
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.2
           tools: composer:v2
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
@@ -46,8 +51,14 @@ jobs:
         run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
-        with:
-          commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
-          file_pattern: '*.php'
-          disable_globbing: true
+        run: |
+          git add -- '*.php'
+
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Apply PHP CS Fixer and Rector changes (CI)"
+          git push

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,6 +20,9 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
+
 jobs:
   psalm:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -37,17 +40,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Static analysis
         run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle --no-cache --php-version=${{ matrix.php }} | cs2pr --graceful-warnings --colorize

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,6 +20,10 @@ on:
 
 name: static analysis
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -40,19 +44,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Static analysis
-        run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle --no-cache --php-version=${{ matrix.php }} | cs2pr --graceful-warnings --colorize
+        env:
+          PHP_VERSION: ${{ matrix.php }}
+        run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle --no-cache --php-version="${PHP_VERSION}" | cs2pr --graceful-warnings --colorize

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- Pin workflow actions to commit SHAs.
- Set read-only GITHUB_TOKEN permissions for read-only workflows.
- Disable persisted checkout credentials where possible.

## Validation
- zizmor --no-progress --no-exit-codes app-api/.github/workflows